### PR TITLE
Add `notranslate` class to currency outputs

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/product-price/index.tsx
@@ -144,6 +144,7 @@ const SalePrice = ( {
 							regularPriceClassName
 						) }
 						style={ regularPriceStyle }
+						translate="no"
 					>
 						{ value }
 					</del>
@@ -163,6 +164,7 @@ const SalePrice = ( {
 							priceClassName
 						) }
 						style={ priceStyle }
+						translate="no"
 					>
 						{ value }
 					</ins>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -75,7 +75,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 				<span class="wc-block-components-totals-item__label">
 					<?php echo esc_html( $subtotal_label ); ?>
 				</span>
-				<span data-wp-text="woocommerce/mini-cart::state.formattedSubtotal" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value">
+				<span data-wp-text="woocommerce/mini-cart::state.formattedSubtotal" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value notranslate">
 				</span>
 				<div class="wc-block-components-totals-item__description">
 					<?php echo esc_html( $other_costs_label ); ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -133,7 +133,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										data-wp-bind--srcset="state.itemSrcset"
 										data-wp-bind--sizes="state.itemSizes"
 										data-wp-on--error="actions.hideImage"
-									>	
+									>
 								</a>
 							</td>
 							<td class="wc-block-cart-item__product">
@@ -149,16 +149,16 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 											<span class="screen-reader-text">
 												<?php esc_html_e( 'Previous price:', 'woocommerce' ); ?>
 											</span>
-											<del data-wp-text="state.priceWithoutDiscount" class="wc-block-components-product-price__regular" translate="no"></del>
+											<del data-wp-text="state.priceWithoutDiscount" class="wc-block-components-product-price__regular notranslate" translate="no"></del>
 											<span class="screen-reader-text">
 												<?php esc_html_e( 'Discounted price:', 'woocommerce' ); ?>
 											</span>
-											<ins data-wp-text="state.itemPrice" class="wc-block-components-product-price__value is-discounted" translate="no"></ins>
+											<ins data-wp-text="state.itemPrice" class="wc-block-components-product-price__value is-discounted notranslate" translate="no"></ins>
 											<span data-wp-text="state.afterItemPrice"></span>
 										</span>
 										<span data-wp-bind--hidden="state.cartItemHasDiscount" class="price wc-block-components-product-price">
 											<span data-wp-text="state.beforeItemPrice"></span>
-											<span data-wp-text="state.itemPrice" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value" translate="no">
+											<span data-wp-text="state.itemPrice" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value notranslate" translate="no">
 											</span>
 											<span data-wp-text="state.afterItemPrice"></span>
 										</span>
@@ -167,35 +167,35 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										<div data-wp-watch="callbacks.itemShortDescription" >
 											<div class="wc-block-components-product-metadata__description"></div>
 										</div>
-										<?php echo $this->render_product_details_markup( 'item_data' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>										
-										<?php echo $this->render_product_details_markup( 'variation' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>																				
+										<?php echo $this->render_product_details_markup( 'item_data' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+										<?php echo $this->render_product_details_markup( 'variation' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 									</div>
 									<div class="wc-block-cart-item__quantity">
 										<div class="wc-block-components-quantity-selector" data-wp-bind--hidden="state.cartItem.sold_individually">
-											<input 
+											<input
 												data-wp-on--input="actions.overrideInvalidQuantity"
-												data-wp-on--change="actions.changeQuantity" 
-												data-wp-bind--aria-label="state.quantityDescriptionLabel" 
-												data-wp-bind--min="state.cartItem.quantity_limits.minimum" 
+												data-wp-on--change="actions.changeQuantity"
+												data-wp-bind--aria-label="state.quantityDescriptionLabel"
+												data-wp-bind--min="state.cartItem.quantity_limits.minimum"
 												data-wp-bind--max="state.cartItem.quantity_limits.maximum"
 												data-wp-bind--value="state.cartItem.quantity"
 												data-wp-bind--readonly="!state.cartItem.quantity_limits.editable"
-												class="wc-block-components-quantity-selector__input" 
-												type="number" 
+												class="wc-block-components-quantity-selector__input"
+												type="number"
 												step="1"
 											>
-											<button 
-												data-wp-bind--disabled="state.minimumReached" 
-												data-wp-on--click="actions.decrementQuantity" 
+											<button
+												data-wp-bind--disabled="state.minimumReached"
+												data-wp-on--click="actions.decrementQuantity"
 												data-wp-bind--aria-label="state.reduceQuantityLabel"
 												data-wp-bind--hidden="!state.cartItem.quantity_limits.editable"
 												class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
 											>
 												−
 											</button>
-											<button 
-												data-wp-bind--disabled="state.maximumReached" 
-												data-wp-on--click="actions.incrementQuantity" 
+											<button
+												data-wp-bind--disabled="state.maximumReached"
+												data-wp-on--click="actions.incrementQuantity"
 												data-wp-bind--aria-label="state.increaseQuantityLabel"
 												data-wp-bind--hidden="!state.cartItem.quantity_limits.editable"
 												class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
@@ -219,11 +219,11 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 							<td class="wc-block-cart-item__total">
 								<div class="wc-block-cart-item__total-price-and-sale-badge-wrapper">
 									<span class="price wc-block-components-product-price">
-										<span data-wp-text="state.lineItemTotal" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value" translate="no">
-										</span>											
+										<span data-wp-text="state.lineItemTotal" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value notranslate" translate="no">
+										</span>
 									</span>
-									<div 
-										data-wp-bind--hidden="!state.cartItemHasDiscount" 
+									<div
+										data-wp-bind--hidden="!state.cartItemHasDiscount"
 										class="wc-block-components-product-badge wc-block-components-sale-badge"
 									>
 									<?php


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://developer.woocommerce.com/docs/contribution/testing/writing-high-quality-testing-instructions/), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Milestone

<!-- DO NOT remove or modify this section (other than to check the box). -->

<!-- milestone-target-selection -->
- [ ] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

> **Note:** Check the box above to have the milestone automatically assigned when merged.
> Alternatively (e.g. for point releases), manually assign the appropriate milestone.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
